### PR TITLE
Fix: Update field name telegram_username

### DIFF
--- a/chatbot/chatbot/doctype/chatbot_party_type/chatbot_party_type.py
+++ b/chatbot/chatbot/doctype/chatbot_party_type/chatbot_party_type.py
@@ -22,17 +22,18 @@ def create_customer_custom_field(party_name):
 					fieldtype="Tab Break",
 				),
 				dict(
-					fieldname="custom_telegram_username",
+					fieldname="telegram_username",
 					label="Telegram Username",
 					fieldtype="Data",
 					insert_after="chatbot_details",
 				),
 				dict(
 					fieldname="telegram_user_id",
+					label="Telegram User ID",
 					read_only=1,
 					label="",
 					fieldtype="Data",
-					insert_after="custom_telegram_username",
+					insert_after="telegram_username",
 				),
 			]
 		})


### PR DESCRIPTION
Field name inconstancy with other utils, getting error:
```
......
      data = b"\xff\x1e\x04#42S22Unknown column 'telegram_username' in 'where clause'"
      errno = 1054
      errval = "Unknown column 'telegram_username' in 'where clause'"
      errorclass = <class 'pymysql.err.OperationalError'>
pymysql.err.OperationalError: (1054, "Unknown column 'telegram_username' in 'where clause'")
```